### PR TITLE
Added template specific admin examples to each template

### DIFF
--- a/code/app_accounts.json
+++ b/code/app_accounts.json
@@ -1,6 +1,6 @@
 {
 	"packages": {
-		"meteor": ["standard-app-packages", "accounts-base", "http", "email", "spiderable", "iron:router", "natestrauser:font-awesome", "matb33:collection-hooks", "perak:user-roles", "copleykj:livestamp"],
+		"meteor": ["accounts-base", "http", "email", "spiderable", "ejson", "random", "iron:router", "natestrauser:font-awesome", "matb33:collection-hooks", "perak:user-roles", "copleykj:livestamp"],
 		"mrt"   : []
 	},
 	"copy_files": [

--- a/code/app_simple.json
+++ b/code/app_simple.json
@@ -1,6 +1,6 @@
 {
 	"packages": {
-		"meteor": ["standard-app-packages", "http", "email", "spiderable", "iron:router", "natestrauser:font-awesome", "matb33:collection-hooks", "copleykj:livestamp"],
+		"meteor": ["http", "email", "spiderable", "ejson", "random", "iron:router", "natestrauser:font-awesome", "matb33:collection-hooks", "copleykj:livestamp"],
 		"mrt"   : []
 	},
 	"copy_files": [

--- a/code/controller_client.js
+++ b/code/controller_client.js
@@ -33,5 +33,6 @@ this.CONTROLLER_NAME = RouteController.extend({
 	},
 
 	onAfterAction: function() {
+		/*AFTER_FUNCTION*/
 	}
 });

--- a/ui/materialize/components/data_view.html
+++ b/ui/materialize/components/data_view.html
@@ -1,5 +1,5 @@
 <template name="TEMPLATE_NAME">
-	<div id="dataview" class="COMPONENT_CLASS">
+	<div id="COMPONENT_ID" class="COMPONENT_CLASS">
 		<h3><span id="component-title-icon" class="COMPONENT_TITLE_ICON_CLASS"></span>COMPONENT_TITLE</h3>
 
 		<form class="form">

--- a/ui/materialize/components/form.html
+++ b/ui/materialize/components/form.html
@@ -1,10 +1,10 @@
 <template name="TEMPLATE_NAME">
-	<div class="COMPONENT_CLASS">
+	<div id="COMPONENT_ID" class="container COMPONENT_CLASS">
 		<div id="form-back-button" class="btn"><i class="material-icons">reply</i>Back</div>
 
 		<h4><span id="component-title-icon" class="COMPONENT_TITLE_ICON_CLASS"></span>COMPONENT_TITLE</h4>
 
-		<form id="form" class="form form_TEMPLATE_NAME" role="form">
+		<form class="form form_TEMPLATE_NAME" role="form">
 			{{#if errorMessage}}
 				<div class="alert alert-warning">{{errorMessage}}</div>
 			{{/if}}
@@ -22,7 +22,7 @@
 <div id="form-input-text" class="form-group FIELD_GROUP_CLASS FIELD_ID">
 	<div class="input-field">
 		<input type="text" name="FIELD_NAME" value="FIELD_VALUE" class="form-control">
-		<label for="FIELD_NAME">FIELD_TITLE</label>
+		<label class="{{#if FIELD_VALUE_RAW}}active{{/if}}" for="FIELD_NAME">FIELD_TITLE</label>
 	</div>
 		<span id="help-text" class="help-block"></span>
 		<span id="error-text" class="help-block"></span>
@@ -31,8 +31,8 @@
 
 <div id="form-input-password" class="form-group FIELD_GROUP_CLASS FIELD_ID">
 	<div class="input-field">
-		<input  type="password" name="FIELD_NAME" value="FIELD_VALUE" class="form-control">
-		<label for="FIELD_NAME">FIELD_TITLE</label>
+		<input type="password" name="FIELD_NAME" value="FIELD_VALUE" class="form-control">
+		<label class="{{#if FIELD_VALUE_RAW}}active{{/if}}" for="FIELD_NAME">FIELD_TITLE</label>
 	</div>
 		<span id="help-text" class="help-block"></span>
 		<span id="error-text" class="help-block"></span>
@@ -40,7 +40,7 @@
 
 <div id="form-input-datepicker" class="form-group FIELD_GROUP_CLASS FIELD_ID">
 	<div class="input-field">
-		<label for="FIELD_NAME">FIELD_TITLE</label>
+		<label class="{{#if FIELD_VALUE_RAW}}active{{/if}}" for="FIELD_NAME">FIELD_TITLE</label>
 		<i class="material-icons prefix">event_note</i>
 		<input  type="text" name="FIELD_NAME" value="FIELD_VALUE">
 	</div>
@@ -51,7 +51,7 @@
 <div id="form-input-read-only" class="form-group FIELD_GROUP_CLASS FIELD_ID">
 	     <div class="input-field">
           <input readonly id="FIELD_NAME" value="FIELD_VALUE" type="text">
-          <label for="FIELD_NAME">FIELD_TITLE</label>
+					<label class="{{#if FIELD_VALUE_RAW}}active{{/if}}" for="FIELD_NAME">FIELD_TITLE</label>
         </div>
 </div>
 
@@ -68,14 +68,14 @@
 <div id="form-input-textarea" class="form-group FIELD_GROUP_CLASS FIELD_ID">
 	<div class="input-field">
 		<textarea class="materialize-textarea" name="FIELD_NAME">FIELD_VALUE</textarea>
-		<label for="FIELD_NAME">FIELD_TITLE</label>
+		<label class="{{#if FIELD_VALUE_RAW}}active{{/if}}" for="FIELD_NAME">FIELD_TITLE</label>
 	</div>
 		<span id="help-text" class="help-block"></span>
 		<span id="error-text" class="help-block"></span>
 </div>
 
 <div id="form-input-radio" class="inline fields form-group FIELD_GROUP_CLASS FIELD_ID">
-	<label for="FIELD_NAME">FIELD_TITLE</label>
+	<label class="{{#if FIELD_VALUE_RAW}}active{{/if}}" for="FIELD_NAME">FIELD_TITLE</label>
 		<div id="form-input-radio-items">
 		</div>
 		<span id="help-text" class="help-block"></span>
@@ -85,7 +85,7 @@
 <div id="form-input-radio-item" class="field">
 	<div class="ui radio checkbox">
 	<input type="radio" value="ITEM_VALUE" name="FIELD_NAME">
-	<label for="FIELD_NAME">FIELD_TITLE</label>
+	<label class="{{#if FIELD_VALUE_RAW}}active{{/if}}" for="FIELD_NAME">FIELD_TITLE</label>
 	</div>
 </div>
 
@@ -100,7 +100,7 @@
 
 <div id="form-input-checkbox-item" class="ui checkbox">
 		<input type="checkbox" value="ITEM_VALUE" name="FIELD_NAME">
-		<label for="FIELD_NAME">FIELD_TITLE</label>
+		<label class="{{#if FIELD_VALUE_RAW}}active{{/if}}" for="FIELD_NAME">FIELD_TITLE</label>
 </div>
 
 <div id="form-input-select" class="form-group FIELD_GROUP_CLASS FIELD_ID">
@@ -116,15 +116,15 @@
 </option>
 
 <div id="form-input-submit" class="">
-	<div class="submit-div">
-		<button id="form-submit-button" class="btn submitbtn" type="submit"> <i class="material-icons">check</i> Save </button>
-		<a href="#" id="form-cancel-button" class="btn"> Cancel </a>
-		<a href="#" id="form-close-button" class="btn green"> OK </a>
+	<div class="input-field submit-div">
+		<button id="form-submit-button" class="btn submitbtn" type="submit"> <i class="material-icons">check</i> SUBMIT_BUTTON_TITLE </button>
+		<a href="#" id="form-cancel-button" class="btn"> CANCEL_BUTTON_TITLE </a>
+		<a href="#" id="form-close-button" class="btn green"> CLOSE_BUTTON_TITLE </a>
 	</div>
 </div>
 
 <div id="form-input-crud" class="FIELD_GROUP_CLASS FIELD_ID">
-	<label for="FIELD_NAME">FIELD_TITLE</label>
+	<label class="active" for="FIELD_NAME">FIELD_TITLE</label>
 	<div class="input-div">
 		<table class="table table-striped">
 			<thead>

--- a/ui/materialize/components/form.js
+++ b/ui/materialize/components/form.js
@@ -110,5 +110,6 @@ Template.TEMPLATE_NAME.helpers({
 	"errorMessage": function() {
 		return pageSession.get("ERROR_MESSAGE_VAR");
 	}
+
 	/*HELPERS_CODE*/
 });

--- a/ui/materialize/examples/materialize_admin.json
+++ b/ui/materialize/examples/materialize_admin.json
@@ -1,0 +1,291 @@
+	{
+	"application": {
+		"title": "Example application",
+		"frontend": "materialize",
+		"roles": [ "admin", "user" ],
+		"default_role": "user",
+		"send_verification_email": true,
+
+		"collections": [
+			{
+				"name": "customers"
+			}
+		],
+
+		"queries": [
+			{
+				"name": "admin_users",
+				"collection": "users",
+				"filter": {}
+			},
+			{
+				"name": "admin_user",
+				"collection": "users",
+				"filter": { "_id": ":userId" },
+				"find_one": true
+			},
+			{
+				"name": "users_null",
+				"collection": "users",
+				"filter": { "_id": null },
+				"find_one": true
+			},
+			{
+				"name": "current_user_data",
+				"collection": "users",
+				"filter": { "_id": "Meteor.userId()" },
+				"find_one": true
+			}
+		],
+
+		"public_zone": {
+			"pages": [
+				{
+					"name": "home_public",
+					"title": "",
+					"components": [
+						{
+							"name": "home_jumbotron",
+							"title": "Example application",
+							"type": "jumbotron",
+							"text": "<b>This is example application built with <a href=\"http://www.meteorkitchen.com\" target=\"_blank\">meteor-kitchen</a> code generator without manual coding.</b><br />It demonstrates simple application with user account system and admin panel.<br />Source code (input file for generator) is <a href=\"https://github.com/perak/kitchen-examples/tree/master/example-admin\" target=\"_blank\">here</a>.",
+							"button_title": "Continue &raquo;",
+							"button_route": "login"
+						}
+					]
+				},
+				{ "name": "login", "template": "login" },
+				{ "name": "register", "template": "register" },
+				{ "name": "verify_email", "template": "verify_email", "route_params": ["verifyEmailToken"] },
+				{ "name": "forgot_password", "template": "forgot_password" },
+				{ "name": "reset_password", "template": "reset_password", "route_params": ["resetPasswordToken"] }
+			],
+
+			"components": [
+				{
+					"name": "left_menu",
+					"type": "menu",
+					"class": "",
+					"title": "Left menu",
+					"dest_selector": "#menu",
+					"items": [
+						{ "title": "Home", "route": "home_public","icon_class":"store" }
+					]
+				},
+
+				{
+					"name": "right_menu",
+					"type": "menu",
+					"class": "",
+					"dest_selector": "#menu",
+					"title": "Right menu",
+					"items": [
+						{ "title": "Register", "route": "register","icon_class":"assignment_ind" },
+						{ "title": "Login", "route": "login","icon_class":"lock_open" }
+					]
+				}
+			]
+		},
+
+		"private_zone": {
+			"pages": [
+				{ "name": "home_private", "title": "Welcome {{userFullName}}!" },
+
+
+				{
+					"name": "admin",
+					"roles": ["admin"],
+					"pages": [
+						{
+							"name": "users",
+							"components": [
+								{
+									"name": "view",
+									"type": "data_view",
+									"title": "Users",
+									"text_if_empty": "No users yet",
+									"query_name": "admin_users",
+									"query_params": [],
+
+									"fields": [
+										{ "name": "profile.name", "title": "Name"},
+										{ "name": "profile.email", "title": "E-mail" },
+										{ "name": "roles", "title": "Role" }
+									],
+
+									"insert_route": "admin.users.insert",
+
+									"edit_route": "admin.users.edit",
+									"edit_route_params": [
+										{ "name": "userId", "value": "this._id" }
+									],
+
+									"details_route": "admin.users.details",
+									"details_route_params": [
+										{ "name": "userId", "value": "this._id" }
+									]
+								}
+							],
+							"pages": [
+								{
+									"name": "details",
+									"route_params": ["userId"],
+									"components": [
+										{
+											"name": "details_form",
+											"type": "form",
+											"mode": "read_only",
+											"title": "User details",
+											"query_name": "admin_user",
+											"query_params": [],
+											"fields": [
+												{ "name": "profile.name", "title": "Name"},
+												{ "name": "profile.email", "title": "E-mail", "type": "email" },
+												{ "name": "roles", "title": "Role" }
+											],
+											"close_route": "admin.users",
+											"back_route": "admin.users"
+										}
+									]
+								},
+								{
+									"name": "insert",
+									"components": [
+										{
+											"name": "insert_form",
+											"type": "form",
+											"mode": "insert",
+											"title": "Add new user",
+											"submit_route": "admin.users",
+											"cancel_route": "admin.users",
+											"query_name": "users_null",
+											"query_params": [],
+											"fields": [
+												{ "name": "profile.name", "title": "Name", "required": true },
+												{ "name": "profile.email", "title": "E-mail", "type": "email", "required": true },
+												{ "name": "password", "title": "Password", "input": "password", "required": true }
+											]
+										}
+									]
+								},
+								{
+									"name": "edit",
+									"route_params": ["userId"],
+									"components": [
+										{
+											"name": "edit_form",
+											"type": "form",
+											"mode": "update",
+											"title": "Edit user",
+											"submit_route": "admin.users",
+											"cancel_route": "admin.users",
+											"query_name": "admin_user",
+											"query_params": [],
+											"fields": [
+												{ "name": "profile.name", "title": "Name", "required": true },
+												{ "name": "profile.email", "title": "E-mail", "type": "email", "required": true },
+												{
+													"name": "roles",
+													"type": "array",
+													"title": "Role",
+													"input": "radio",
+													"input_items": [
+														{ "value": "user", "title": "User" },
+														{ "value": "admin", "title": "Admin" },
+														{ "value": "blocked", "title": "Blocked" }
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+
+					],
+
+					"components": [
+						{
+							"name": "side_menu",
+							"type": "menu",
+							"class": "collection",
+							"items": [
+								{ "title": "Users", "route": "admin.users","class": "collection-item"}
+							]
+						}
+					]
+				},
+
+				{
+					"name": "user_settings",
+					"roles": ["user", "admin"],
+					"pages": [
+						{
+							"name": "profile",
+							"components": [
+								{
+									"name": "edit_form",
+									"type": "form",
+									"mode": "update",
+									"title": "Edit your profile",
+									"submit_route": "user_settings.profile",
+									"query_name": "current_user_data",
+									"query_params": [],
+									"fields": [
+										{ "name": "profile.name", "title": "Name", "required": true },
+										{ "name": "profile.email", "title": "E-mail", "type": "email", "required": true },
+										{ "name": "profile.facebook", "title": "Facebook URL" },
+										{ "name": "profile.google", "title": "Google+ URL" },
+										{ "name": "profile.twitter", "title": "Twitter ID" },
+										{ "name": "profile.website", "title": "Website URL" }
+									]
+								}
+							]
+						},
+
+						{ "name": "change_pass", "template": "change_pass" }
+					],
+
+					"components": [
+						{
+							"name": "side_menu",
+							"type": "menu",
+							"class": "collection",
+							"items": [
+								{ "title": "Profile", "route": "user_settings.profile","class":"collection-item" },
+								{ "title": "Change password", "route": "user_settings.change_pass","class":"collection-item" }
+							]
+						}
+					]
+				},
+
+				{ "name": "logout", "template": "logout" }
+			],
+
+			"components": [
+				{
+					"name": "left_menu",
+					"type": "menu",
+					"title": "Left menu",
+					"class": "",
+					"dest_selector": "#menu",
+					"items": [
+						{ "title": "Home", "route": "home_private", "icon_class": "home" }
+					]
+				},
+				{
+					"name": "right_menu",
+					"type": "menu",
+					"title": "Right menu",
+					"class": "right",
+					"dest_selector": "#menu",
+					"items": [
+						{ "title": "Admin", "route": "admin", "icon_class": "brightness_auto" },
+						{ "title": "Settings", "route": "user_settings","icon_class":"settings" },
+						{ "title": "Logout", "route": "logout","icon_class":"power_settings_new" }
+					]
+				}
+			]
+		}
+	}
+}

--- a/ui/materialize/examples/materialize_sidemenu_admin.json
+++ b/ui/materialize/examples/materialize_sidemenu_admin.json
@@ -1,0 +1,297 @@
+	{
+	"application": {
+		"title": "Example application",
+		"frontend": "materialize",
+		"roles": [ "admin", "user" ],
+		"default_role": "user",
+		"send_verification_email": true,
+
+		"collections": [
+			{
+				"name": "customers"
+			}
+		],
+
+		"queries": [
+			{
+				"name": "admin_users",
+				"collection": "users",
+				"filter": {}
+			},
+			{
+				"name": "admin_user",
+				"collection": "users",
+				"filter": { "_id": ":userId" },
+				"find_one": true
+			},
+			{
+				"name": "users_null",
+				"collection": "users",
+				"filter": { "_id": null },
+				"find_one": true
+			},
+			{
+				"name": "current_user_data",
+				"collection": "users",
+				"filter": { "_id": "Meteor.userId()" },
+				"find_one": true
+			}
+		],
+
+		"public_zone": {
+			"layout": "sidemenu",
+			"pages": [
+				{
+					"name": "home_public",
+					"title": "",
+					"components": [
+						{
+							"name": "home_jumbotron",
+							"title": "Example application",
+							"type": "jumbotron",
+							"text": "<b>This is example application built with <a href=\"http://www.meteorkitchen.com\" target=\"_blank\">meteor-kitchen</a> code generator without manual coding.</b><br />It demonstrates simple application with user account system and admin panel.<br />Source code (input file for generator) is <a href=\"https://github.com/perak/kitchen-examples/tree/master/example-admin\" target=\"_blank\">here</a>.",
+							"button_title": "Continue &raquo;",
+							"button_route": "login"
+						}
+					]
+				},
+				{ "name": "login", "template": "login" },
+				{ "name": "register", "template": "register" },
+				{ "name": "verify_email", "template": "verify_email", "route_params": ["verifyEmailToken"] },
+				{ "name": "forgot_password", "template": "forgot_password" },
+				{ "name": "reset_password", "template": "reset_password", "route_params": ["resetPasswordToken"] }
+			],
+
+			"components": [
+				{
+					"name": "left_menu",
+					"type": "menu",
+					"template":"sidemenu",
+					"class": "",
+					"title": "Left menu",
+					"dest_selector": "#menu",
+					"items": [
+						{ "title": "Home", "route": "home_public","icon_class":"store" }
+					]
+				},
+
+				{
+					"name": "right_menu",
+					"type": "menu",
+					"template":"sidemenu",
+					"class": "",
+					"dest_selector": "#menu",
+					"title": "Right menu",
+					"items": [
+						{ "title": "Register", "route": "register","icon_class":"assignment_ind" },
+						{ "title": "Login", "route": "login","icon_class":"lock_open" }
+					]
+				}
+			]
+		},
+
+		"private_zone": {
+			"layout":"sidemenu",
+			"pages": [
+				{ "name": "home_private", "title": "Welcome {{userFullName}}!" },
+
+
+				{
+					"name": "admin",
+					"roles": ["admin"],
+					"pages": [
+						{
+							"name": "users",
+							"components": [
+								{
+									"name": "view",
+									"type": "data_view",
+									"title": "Users",
+									"text_if_empty": "No users yet",
+									"query_name": "admin_users",
+									"query_params": [],
+
+									"fields": [
+										{ "name": "profile.name", "title": "Name"},
+										{ "name": "profile.email", "title": "E-mail" },
+										{ "name": "roles", "title": "Role" }
+									],
+
+									"insert_route": "admin.users.insert",
+
+									"edit_route": "admin.users.edit",
+									"edit_route_params": [
+										{ "name": "userId", "value": "this._id" }
+									],
+
+									"details_route": "admin.users.details",
+									"details_route_params": [
+										{ "name": "userId", "value": "this._id" }
+									]
+								}
+							],
+							"pages": [
+								{
+									"name": "details",
+									"route_params": ["userId"],
+									"components": [
+										{
+											"name": "details_form",
+											"type": "form",
+											"mode": "read_only",
+											"title": "User details",
+											"query_name": "admin_user",
+											"query_params": [],
+											"fields": [
+												{ "name": "profile.name", "title": "Name"},
+												{ "name": "profile.email", "title": "E-mail", "type": "email" },
+												{ "name": "roles", "title": "Role" }
+											],
+											"close_route": "admin.users",
+											"back_route": "admin.users"
+										}
+									]
+								},
+								{
+									"name": "insert",
+									"components": [
+										{
+											"name": "insert_form",
+											"type": "form",
+											"mode": "insert",
+											"title": "Add new user",
+											"submit_route": "admin.users",
+											"cancel_route": "admin.users",
+											"query_name": "users_null",
+											"query_params": [],
+											"fields": [
+												{ "name": "profile.name", "title": "Name", "required": true },
+												{ "name": "profile.email", "title": "E-mail", "type": "email", "required": true },
+												{ "name": "password", "title": "Password", "input": "password", "required": true }
+											]
+										}
+									]
+								},
+								{
+									"name": "edit",
+									"route_params": ["userId"],
+									"components": [
+										{
+											"name": "edit_form",
+											"type": "form",
+											"mode": "update",
+											"title": "Edit user",
+											"submit_route": "admin.users",
+											"cancel_route": "admin.users",
+											"query_name": "admin_user",
+											"query_params": [],
+											"fields": [
+												{ "name": "profile.name", "title": "Name", "required": true },
+												{ "name": "profile.email", "title": "E-mail", "type": "email", "required": true },
+												{
+													"name": "roles",
+													"type": "array",
+													"title": "Role",
+													"input": "radio",
+													"input_items": [
+														{ "value": "user", "title": "User" },
+														{ "value": "admin", "title": "Admin" },
+														{ "value": "blocked", "title": "Blocked" }
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+
+					],
+
+					"components": [
+						{
+							"name": "side_menu",
+							"type": "menu",
+							"class": "nav nav-stacked nav-pills",
+							"items": [
+								{ "title": "Users", "route": "admin.users" }
+							]
+						}
+					]
+				},
+
+				{
+					"name": "user_settings",
+					"roles": ["user", "admin"],
+					"pages": [
+						{
+							"name": "profile",
+							"components": [
+								{
+									"name": "edit_form",
+									"type": "form",
+									"mode": "update",
+									"title": "Edit your profile",
+									"submit_route": "user_settings.profile",
+									"query_name": "current_user_data",
+									"query_params": [],
+									"fields": [
+										{ "name": "profile.name", "title": "Name", "required": true },
+										{ "name": "profile.email", "title": "E-mail", "type": "email", "required": true },
+										{ "name": "profile.facebook", "title": "Facebook URL" },
+										{ "name": "profile.google", "title": "Google+ URL" },
+										{ "name": "profile.twitter", "title": "Twitter ID" },
+										{ "name": "profile.website", "title": "Website URL" }
+									]
+								}
+							]
+						},
+
+						{ "name": "change_pass", "template": "change_pass" }
+					],
+
+					"components": [
+						{
+							"name": "side_menu",
+							"type": "menu",
+							"class": "ui vertical menu",
+							"items": [
+								{ "title": "Profile", "route": "user_settings.profile" },
+								{ "title": "Change password", "route": "user_settings.change_pass" }
+							]
+						}
+					]
+				},
+
+				{ "name": "logout", "template": "logout" }
+			],
+
+			"components": [
+				{
+					"name": "left_menu",
+					"type": "menu",
+					"title": "Left menu",
+					"template":"sidemenu",
+					"class": "",
+					"dest_selector": "#menu",
+					"items": [
+						{ "title": "Home", "route": "home_private", "icon_class": "home" }
+					]
+				},
+				{
+					"name": "right_menu",
+					"type": "menu",
+					"title": "Right menu",
+					"template":"sidemenu",
+					"class": "",
+					"dest_selector": "#menu",
+					"items": [
+						{ "title": "Admin", "route": "admin", "icon_class": "brightness_auto" },
+						{ "title": "Settings", "route": "user_settings","icon_class":"settings" },
+						{ "title": "Logout", "route": "logout","icon_class":"power_settings_new" }
+					]
+				}
+			]
+		}
+	}
+}

--- a/ui/semantic-ui/examples/semanticui_admin.json
+++ b/ui/semantic-ui/examples/semanticui_admin.json
@@ -1,0 +1,295 @@
+	{
+	"application": {
+		"title": "Example application",
+		"frontend": "semantic-ui",
+
+		"roles": [ "admin", "user" ],
+		"default_role": "user",
+		"send_verification_email": true,
+
+		"collections": [
+			{
+				"name": "customers"
+			}
+		],
+
+		"queries": [
+			{
+				"name": "admin_users",
+				"collection": "users",
+				"filter": {}
+			},
+			{
+				"name": "admin_user",
+				"collection": "users",
+				"filter": { "_id": ":userId" },
+				"find_one": true
+			},
+			{
+				"name": "users_null",
+				"collection": "users",
+				"filter": { "_id": null },
+				"find_one": true
+			},
+			{
+				"name": "current_user_data",
+				"collection": "users",
+				"filter": { "_id": "Meteor.userId()" },
+				"find_one": true
+			}
+		],
+
+		"public_zone": {
+			"pages": [
+				{
+					"name": "home_public",
+					"title": "",
+					"components": [
+						{
+							"name": "home_jumbotron",
+							"title": "Example application",
+							"type": "jumbotron",
+							"text": "<b>This is example application built with <a href=\"http://www.meteorkitchen.com\" target=\"_blank\">meteor-kitchen</a> code generator without manual coding.</b><br />It demonstrates simple application with user account system and admin panel.<br />Source code (input file for generator) is <a href=\"https://github.com/perak/kitchen-examples/tree/master/example-admin\" target=\"_blank\">here</a>.",
+							"button_title": "Continue &raquo;",
+							"button_route": "login"
+						}
+					]
+				},
+				{ "name": "login", "template": "login" },
+				{ "name": "register", "template": "register" },
+				{ "name": "verify_email", "template": "verify_email", "route_params": ["verifyEmailToken"] },
+				{ "name": "forgot_password", "template": "forgot_password" },
+				{ "name": "reset_password", "template": "reset_password", "route_params": ["resetPasswordToken"] }
+			],
+
+			"components": [
+				{
+					"name": "left_menu",
+					"type": "menu",
+					"class": "nav navbar-nav",
+					"dest_selector": "#menu",
+					"items": [
+						{ "title": "Home", "route": "home_public" }
+					]
+				},
+
+				{
+					"name": "right_menu",
+					"type": "menu",
+					"class": "right menu",
+					"dest_selector": "#menu",
+					"items": [
+						{ "title": "Register", "route": "register" },
+						{ "title": "Login", "route": "login" }
+					]
+				}
+			]
+		},
+
+		"private_zone": {
+			"pages": [
+				{ "name": "home_private", "title": "Welcome {{userFullName}}!" },
+
+
+				{
+					"name": "admin",
+					"roles": ["admin"],
+					"pages": [
+						{
+							"name": "users",
+							"components": [
+								{
+									"name": "view",
+									"type": "data_view",
+									"title": "Users",
+									"text_if_empty": "No users yet",
+									"query_name": "admin_users",
+									"query_params": [],
+
+									"fields": [
+										{ "name": "profile.name", "title": "Name"},
+										{ "name": "profile.email", "title": "E-mail" },
+										{ "name": "roles", "title": "Role" }
+									],
+
+									"insert_route": "admin.users.insert",
+
+									"edit_route": "admin.users.edit",
+									"edit_route_params": [
+										{ "name": "userId", "value": "this._id" }
+									],
+
+									"details_route": "admin.users.details",
+									"details_route_params": [
+										{ "name": "userId", "value": "this._id" }
+									]
+								}
+							],
+							"pages": [
+								{
+									"name": "details",
+									"route_params": ["userId"],
+									"components": [
+										{
+											"name": "details_form",
+											"type": "form",
+											"mode": "read_only",
+											"title": "User details",
+											"query_name": "admin_user",
+											"query_params": [],
+											"fields": [
+												{ "name": "profile.name", "title": "Name"},
+												{ "name": "profile.email", "title": "E-mail", "type": "email" },
+												{ "name": "roles", "title": "Role" }
+											],
+											"close_route": "admin.users",
+											"back_route": "admin.users"
+										}
+									]
+								},
+								{
+									"name": "insert",
+									"components": [
+										{
+											"name": "insert_form",
+											"type": "form",
+											"mode": "insert",
+											"title": "Add new user",
+											"submit_route": "admin.users",
+											"cancel_route": "admin.users",
+											"query_name": "users_null",
+											"query_params": [],
+											"fields": [
+												{ "name": "profile.name", "title": "Name", "required": true },
+												{ "name": "profile.email", "title": "E-mail", "type": "email", "required": true },
+												{ "name": "password", "title": "Password", "input": "password", "required": true }
+											]
+										}
+									]
+								},
+								{
+									"name": "edit",
+									"route_params": ["userId"],
+									"components": [
+										{
+											"name": "edit_form",
+											"type": "form",
+											"mode": "update",
+											"title": "Edit user",
+											"submit_route": "admin.users",
+											"cancel_route": "admin.users",
+											"query_name": "admin_user",
+											"query_params": [],
+											"fields": [
+												{ "name": "profile.name", "title": "Name", "required": true },
+												{ "name": "profile.email", "title": "E-mail", "type": "email", "required": true },
+												{
+													"name": "roles",
+													"type": "array",
+													"title": "Role",
+													"input": "radio",
+													"input_items": [
+														{ "value": "user", "title": "User" },
+														{ "value": "admin", "title": "Admin" },
+														{ "value": "blocked", "title": "Blocked" }
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+
+					],
+
+					"components": [
+						{
+							"name": "side_menu",
+							"type": "menu",
+							"class": "nav nav-stacked nav-pills",
+							"items": [
+								{ "title": "Users", "route": "admin.users" }
+							]
+						}
+					]
+				},
+
+				{
+					"name": "user_settings",
+					"roles": ["user", "admin"],
+					"pages": [
+						{
+							"name": "profile",
+							"components": [
+								{
+									"name": "edit_form",
+									"type": "form",
+									"mode": "update",
+									"title": "Edit your profile",
+									"submit_route": "user_settings.profile",
+									"query_name": "current_user_data",
+									"query_params": [],
+									"fields": [
+										{ "name": "profile.name", "title": "Name", "required": true },
+										{ "name": "profile.email", "title": "E-mail", "type": "email", "required": true },
+										{ "name": "profile.facebook", "title": "Facebook URL" },
+										{ "name": "profile.google", "title": "Google+ URL" },
+										{ "name": "profile.twitter", "title": "Twitter ID" },
+										{ "name": "profile.website", "title": "Website URL" }
+									]
+								}
+							]
+						},
+
+						{ "name": "change_pass", "template": "change_pass" }
+					],
+
+					"components": [
+						{
+							"name": "side_menu",
+							"type": "menu",
+							"class": "ui vertical menu",
+							"items": [
+								{ "title": "Profile", "route": "user_settings.profile" },
+								{ "title": "Change password", "route": "user_settings.change_pass" }
+							]
+						}
+					]
+				},
+
+				{ "name": "logout", "template": "logout" }
+			],
+
+			"components": [
+				{
+					"name": "left_menu",
+					"type": "menu",
+					"class": "nav navbar-nav",
+					"dest_selector": "#menu",
+					"items": [
+						{ "title": "Home", "route": "home_private", "icon_class": "fa fa-home" }
+					]
+				},
+				{
+					"name": "right_menu",
+					"type": "menu",
+					"class": "right menu",
+					"dest_selector": "#menu",
+					"items": [
+						{ "title": "Admin", "route": "admin", "icon_class": "fa fa-wrench" },
+
+						{
+							"title": "{{userEmail}}",
+							"items": [
+								{ "title": "Settings", "route": "user_settings" },
+								{ "title": "Logout", "route": "logout" }
+							],
+							"icon_class": "fa fa-cog"
+						}
+					]
+				}
+			]
+		}
+	}
+}

--- a/ui/semantic-ui/examples/semanticui_sidemenu_admin.json
+++ b/ui/semantic-ui/examples/semanticui_sidemenu_admin.json
@@ -1,0 +1,293 @@
+	{
+	"application": {
+		"title": "Example application",
+		"frontend": "materialize",
+		"roles": [ "admin", "user" ],
+		"default_role": "user",
+		"send_verification_email": true,
+
+		"collections": [
+			{
+				"name": "customers"
+			}
+		],
+
+		"queries": [
+			{
+				"name": "admin_users",
+				"collection": "users",
+				"filter": {}
+			},
+			{
+				"name": "admin_user",
+				"collection": "users",
+				"filter": { "_id": ":userId" },
+				"find_one": true
+			},
+			{
+				"name": "users_null",
+				"collection": "users",
+				"filter": { "_id": null },
+				"find_one": true
+			},
+			{
+				"name": "current_user_data",
+				"collection": "users",
+				"filter": { "_id": "Meteor.userId()" },
+				"find_one": true
+			}
+		],
+
+		"public_zone": {
+			"layout": "sidemenu",
+			"pages": [
+				{
+					"name": "home_public",
+					"title": "",
+					"components": [
+						{
+							"name": "home_jumbotron",
+							"title": "Example application",
+							"type": "jumbotron",
+							"text": "<b>This is example application built with <a href=\"http://www.meteorkitchen.com\" target=\"_blank\">meteor-kitchen</a> code generator without manual coding.</b><br />It demonstrates simple application with user account system and admin panel.<br />Source code (input file for generator) is <a href=\"https://github.com/perak/kitchen-examples/tree/master/example-admin\" target=\"_blank\">here</a>.",
+							"button_title": "Continue &raquo;",
+							"button_route": "login"
+						}
+					]
+				},
+				{ "name": "login", "template": "login" },
+				{ "name": "register", "template": "register" },
+				{ "name": "verify_email", "template": "verify_email", "route_params": ["verifyEmailToken"] },
+				{ "name": "forgot_password", "template": "forgot_password" },
+				{ "name": "reset_password", "template": "reset_password", "route_params": ["resetPasswordToken"] }
+			],
+
+			"components": [
+				{
+					"name": "left_menu",
+					"type": "menu",
+					"template":"sidemenu",
+					"class": "ui icon left inline vertical sidebar menu left_menu",
+					"dest_selector": "#menu",
+					"items": [
+						{ "title": "Home", "route": "home_public","icon_class":"blue home icon" }
+					]
+				},
+
+				{
+					"name": "right_menu",
+					"type": "menu",
+					"template":"sidemenu",
+					"class": "ui icon right inline vertical sidebar menu right_menu",
+					"dest_selector": "#menu",
+					"items": [
+						{ "title": "Register", "route": "register","icon_class":"orange add user icon" },
+						{ "title": "Login", "route": "login","icon_class":"blue sign in icon" }
+					]
+				}
+			]
+		},
+
+		"private_zone": {
+			"layout":"sidemenu",
+			"pages": [
+				{ "name": "home_private", "title": "Welcome {{userFullName}}!" },
+
+
+				{
+					"name": "admin",
+					"roles": ["admin"],
+					"pages": [
+						{
+							"name": "users",
+							"components": [
+								{
+									"name": "view",
+									"type": "data_view",
+									"title": "Users",
+									"text_if_empty": "No users yet",
+									"query_name": "admin_users",
+									"query_params": [],
+
+									"fields": [
+										{ "name": "profile.name", "title": "Name"},
+										{ "name": "profile.email", "title": "E-mail" },
+										{ "name": "roles", "title": "Role" }
+									],
+
+									"insert_route": "admin.users.insert",
+
+									"edit_route": "admin.users.edit",
+									"edit_route_params": [
+										{ "name": "userId", "value": "this._id" }
+									],
+
+									"details_route": "admin.users.details",
+									"details_route_params": [
+										{ "name": "userId", "value": "this._id" }
+									]
+								}
+							],
+							"pages": [
+								{
+									"name": "details",
+									"route_params": ["userId"],
+									"components": [
+										{
+											"name": "details_form",
+											"type": "form",
+											"mode": "read_only",
+											"title": "User details",
+											"query_name": "admin_user",
+											"query_params": [],
+											"fields": [
+												{ "name": "profile.name", "title": "Name"},
+												{ "name": "profile.email", "title": "E-mail", "type": "email" },
+												{ "name": "roles", "title": "Role" }
+											],
+											"close_route": "admin.users",
+											"back_route": "admin.users"
+										}
+									]
+								},
+								{
+									"name": "insert",
+									"components": [
+										{
+											"name": "insert_form",
+											"type": "form",
+											"mode": "insert",
+											"title": "Add new user",
+											"submit_route": "admin.users",
+											"cancel_route": "admin.users",
+											"query_name": "users_null",
+											"query_params": [],
+											"fields": [
+												{ "name": "profile.name", "title": "Name", "required": true },
+												{ "name": "profile.email", "title": "E-mail", "type": "email", "required": true },
+												{ "name": "password", "title": "Password", "input": "password", "required": true }
+											]
+										}
+									]
+								},
+								{
+									"name": "edit",
+									"route_params": ["userId"],
+									"components": [
+										{
+											"name": "edit_form",
+											"type": "form",
+											"mode": "update",
+											"title": "Edit user",
+											"submit_route": "admin.users",
+											"cancel_route": "admin.users",
+											"query_name": "admin_user",
+											"query_params": [],
+											"fields": [
+												{ "name": "profile.name", "title": "Name", "required": true },
+												{ "name": "profile.email", "title": "E-mail", "type": "email", "required": true },
+												{
+													"name": "roles",
+													"type": "array",
+													"title": "Role",
+													"input": "radio",
+													"input_items": [
+														{ "value": "user", "title": "User" },
+														{ "value": "admin", "title": "Admin" },
+														{ "value": "blocked", "title": "Blocked" }
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+
+					],
+
+					"components": [
+						{
+							"name": "side_menu",
+							"type": "menu",
+							"class": "nav nav-stacked nav-pills",
+							"items": [
+								{ "title": "Users", "route": "admin.users" }
+							]
+						}
+					]
+				},
+
+				{
+					"name": "user_settings",
+					"roles": ["user", "admin"],
+					"pages": [
+						{
+							"name": "profile",
+							"components": [
+								{
+									"name": "edit_form",
+									"type": "form",
+									"mode": "update",
+									"title": "Edit your profile",
+									"submit_route": "user_settings.profile",
+									"query_name": "current_user_data",
+									"query_params": [],
+									"fields": [
+										{ "name": "profile.name", "title": "Name", "required": true },
+										{ "name": "profile.email", "title": "E-mail", "type": "email", "required": true },
+										{ "name": "profile.facebook", "title": "Facebook URL" },
+										{ "name": "profile.google", "title": "Google+ URL" },
+										{ "name": "profile.twitter", "title": "Twitter ID" },
+										{ "name": "profile.website", "title": "Website URL" }
+									]
+								}
+							]
+						},
+
+						{ "name": "change_pass", "template": "change_pass" }
+					],
+
+					"components": [
+						{
+							"name": "side_menu",
+							"type": "menu",
+							"class": "ui vertical menu",
+							"items": [
+								{ "title": "Profile", "route": "user_settings.profile" },
+								{ "title": "Change password", "route": "user_settings.change_pass" }
+							]
+						}
+					]
+				},
+
+				{ "name": "logout", "template": "logout" }
+			],
+
+			"components": [
+				{
+					"name": "left_menu",
+					"type": "menu",
+					"template":"sidemenu",
+					"class": "ui icon left inline vertical sidebar menu left_menu",
+					"dest_selector": "#menu",
+					"items": [
+						{ "title": "Home", "route": "home_private", "icon_class": "home icon" }
+					]
+				},
+				{
+					"name": "right_menu",
+					"type": "menu",
+					"template":"sidemenu",
+					"class": "ui icon right inline vertical sidebar menu right_menu",
+					"dest_selector": "#menu",
+					"items": [
+						{ "title": "Admin", "route": "admin", "icon_class": "blue spy icon" },
+						{ "title": "Settings", "route": "user_settings","icon_class":"orange settings icon" },
+						{ "title": "Logout", "route": "logout","icon_class":"red sign out icon" }
+					]
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
There are some minor modifications should be done in example json files if semantic or materialize templates are used.

Changes are mostly related to menu classes  but new json files are also a good demo of using custom layouts for zones.

In future json files should be as free as possible from template specific classes.

Fixed fancy materializecss labels with `<label class="{{#if FIELD_VALUE_RAW}}active{{/if}}" for="FIELD_NAME">FIELD_TITLE</label>`
