### PR TITLE
Fixed Materialize modals for removing collection items

### DIFF
--- a/ui/materialize/components/data_view_table.html
+++ b/ui/materialize/components/data_view_table.html
@@ -16,11 +16,11 @@
       <p>Delete? Are you sure?</p>
     </div>
     <div class="modal-footer">
-	      <div class="red btn modal-action modal-close waves-effect waves-green">
+	      <div class="red btn modal-action modal-close modal-deny waves-effect waves-green">
 	        <i class="remove icon"></i>No
 	      </div>
 
-	      <div class="green btn modal-action modal-close waves-effect waves-green">
+	      <div class="green btn modal-action modal-close modal-confirm waves-effect waves-green">
 	        <i class="checkmark icon"></i>Yes
 	      </div>
     </div>

--- a/ui/materialize/components/data_view_table_items.js
+++ b/ui/materialize/components/data_view_table_items.js
@@ -27,17 +27,26 @@ Template.TEMPLATE_NAME.events({
 
 	"click #delete-button": function(e, t) {
 		e.preventDefault();
-		var me = this;
-		  $('.modal').openModal({
-			  dismissible: true, // Modal can be dismissed by clicking outside of the modal
-			  opacity: .5, // Opacity of modal background
-			  in_duration: 300, // Transition in duration
-			  out_duration: 200, // Transition out duration
-			  ready: function() { }, // Callback for Modal open
-			  complete: function(e) { console.log(e);/*COLLECTION_VAR.remove({ _id: me._id });*/ } // Callback for Modal close
-			});
+
+		var me = this,
+			el = $('.modal');
+
+		el.openModal({
+			dismissible: true, // Modal can be dismissed by clicking outside of the modal
+			opacity: .5, // Opacity of modal background
+			in_duration: 300, // Transition in duration
+			out_duration: 200, // Transition out duration
+			ready: function() {
+				el.find('.modal-confirm').on('click', function() {
+					COLLECTION_VAR.remove({ _id: me._id });
+				});
+			}, // Callback for Modal open
+			complete: function() {  } // Callback for Modal close
+		});
+
 		return false;
 	},
+
 	"click #edit-button": function(e, t) {
 		e.preventDefault();
 		/*EDIT_ROUTE*/


### PR DESCRIPTION
I'm not sure whether this is the best approach for Meteor, but it was the simplest approach.

It involves using another manual jQuery selector, but since we already did that in order to open the modal and we're just finding a child element of the modal I don't think it should be an issue.

Open to other suggestions though.
